### PR TITLE
Update minimal-status.tmux

### DIFF
--- a/theme/minimal-status.tmux
+++ b/theme/minimal-status.tmux
@@ -4,4 +4,4 @@ set-option -g status-justify centre
 set-option -g status-left '#[bg=default,fg=default,bold]#{?client_prefix,,  tmux  }#[bg=#698DDA,fg=black,bold]#{?client_prefix,  tmux  ,}'
 set-option -g status-right '#S'
 set-option -g window-status-format ' #I:#W '
-set-option -g window-status-current-format '#[bg=#698DDA,fg=black] #I:#W#{?window_zoomed_flag,  , }'
+set-option -g window-status-current-format '#[bg=#698DDA,fg=#000000] #I:#W#{?window_zoomed_flag,  , }'


### PR DESCRIPTION
Replaced 'black' with '#000000'. Black was appearing as grey on kitty terminal, so I replaced it with its hex code.

This doesn't break anything for other terminals. Tested on the following
- Kitty Terminal
- Alacritty Terminal
- Gnome Terminal

Before:
![image](https://github.com/niksingh710/minimal-tmux-status/assets/66197648/a6bd42b4-32a3-44dd-b473-c9863b0992d1)

After:
![image](https://github.com/niksingh710/minimal-tmux-status/assets/66197648/49c8b268-074d-4575-8eee-8df69657a123)
