### PR TITLE
Added an option to round selection box

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ set -g @minimal-tmux-show-expanded-icons-for-all-tabs true
 set -g @minimal-tmux-status-right-extra ""
 set -g @minimal-tmux-status-left-extra ""
 
+# To make the selection box rounded () or edged <> 
+# Default is nothing, when set to true default is edged
+set -g @minimal-tmux-use-arrow true
+set -g @minimal-tmux-right-arrow ""
+set -g @minimal-tmux-left-arrow ""
+
 # Not recommended to change these values
 set -g @minimal-tmux-status-right "#S"
 set -g @minimal-tmux-status-left "refer to code"

--- a/minimal.tmux
+++ b/minimal.tmux
@@ -11,7 +11,14 @@ get_tmux_option() {
 	fi
 	echo "$default_value"
 }
-
+use_arrow=$(get_tmux_option "@minimal-tmux-use-arrow" false)
+if "$use_arrow"; then
+	rarrow=$(get_tmux_option "@minimal-tmux-right-arrow" "")
+	larrow=$(get_tmux_option "@minimal-tmux-left-arrow" "")
+else
+	larrow=""
+	rarrow=""
+fi
 bg=$(get_tmux_option "@minimal-tmux-bg" '#698DDA')
 fg=$(get_tmux_option "@minimal-tmux-fg" '#000000')
 
@@ -51,8 +58,7 @@ tmux set-option -g status-justify "${justify}"
 tmux set-option -g status-left "${status_left_extra}"
 tmux set-option -g status-right "${status_right_extra}"
 tmux set-option -g window-status-format "${window_status_format}"
-tmux set-option -g window-status-current-format "#[bg=${bg},fg=${fg}] ${window_status_format}#{?window_zoomed_flag,${expanded_icon}, }"
-
+tmux set-option -g window-status-current-format "#[fg=${bg}]$larrow#[bg=${bg},fg=${fg}]${window_status_format}#[fg=${bg},bg=default]$rarrow#{?window_zoomed_flag,${expanded_icon}, }"
 if [ "$show_expanded_icon_for_all_tabs" = true ]; then
 	tmux set-option -g window-status-format " ${window_status_format}#{?window_zoomed_flag,${expanded_icon}, }"
 fi


### PR DESCRIPTION
Heya!

I really liked this code base but wanted the possibility to have the rounded or angles edges on the box selection that you see in for example Powerlevel2K so I added that option within the codebase and documented it.

The default is still that the UI behaves exactly as it always has i.e. it creates a box around the current tmux window.
However if a user sets the new @minimal-tmux-use-arrow option to true then the box will have edges around it like so
<box>
and with the right and left arrow options the user can use their own endings to have the box end in whatever way they want.

My original use case was to get the box but rounded, within the docs you can see the working example of that.
I have tested that the original functionality is untouched, and that both the edged (i.e. <box>) and rounded box ( i.e. (box) ) work.

Please let me know if there's anything else needed to get the pull request in order!
![image](https://github.com/user-attachments/assets/0807dab0-b44b-4506-8c1f-21ecdaad5448)
