### PR TITLE
Fixes a small typo in the config example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ set -g @minimal-tmux-expanded-icon "󰊓 "
 
 # on all tabs (default is false)
 # false will make it visible for the current tab only
-set -g @minimal-tmux-show-expanded-icons-for-all-tabs true
+set -g @minimal-tmux-show-expanded-icon-for-all-tabs true
 
 # To add or remove extra text in status bar
 set -g @minimal-tmux-status-right-extra ""


### PR DESCRIPTION
In the example config the variable used to show the expanded icon on all tabs is named `@minimal-tmux-show-expanded-icons-for-all-tabs`, but in the `minimal.tmux` file, in line 69 [1] the expected name is `@minimal-tmux-show-expanded-icon-for-all-tabs`, with `icon` instead of `icons`. If this config is used, changes to the value of that variable are ignored by the main config.

This PR only changes the example shown so it matches the expected value.

[1] https://github.com/niksingh710/minimal-tmux-status/blob/118b44b05b3fb4e46a38373ddcef35d4c5e2d01e/minimal.tmux#L69