### PR TITLE
fix: remove indicator spacing

### DIFF
--- a/minimal.tmux
+++ b/minimal.tmux
@@ -53,7 +53,7 @@ justify=$(get_tmux_option "@minimal-tmux-justify" "centre")
 
 indicator_state=$(get_tmux_option "@minimal-tmux-indicator" true)
 indicator_str=$(get_tmux_option "@minimal-tmux-indicator-str" " tmux ")
-indicator=$("$indicator_state" && echo " $indicator_str ")
+indicator=$("$indicator_state" && echo "$indicator_str")
 
 right_state=$(get_tmux_option "@minimal-tmux-right" true)
 left_state=$(get_tmux_option "@minimal-tmux-left" true)


### PR DESCRIPTION
Resolves #25

I removed the surrounding whitespace in the plugin. Users can still opt into that behavior themselves by including spaces in their custom `indicator_str` if they want them.